### PR TITLE
added computation of noise strength kernel

### DIFF
--- a/src/specfem2D/compute_kernels.f90
+++ b/src/specfem2D/compute_kernels.f90
@@ -83,13 +83,15 @@
                          nspec,ibool,accel_elastic,b_displ_elastic, &
                          P_SV,displ_elastic, &
                          ibool,hprime_xx,hprime_zz,xix,xiz,gammax,gammaz, &
-                         GPU_MODE
+                         GPU_MODE,NOISE_TOMOGRAPHY
 
   use specfem_par_gpu, only: Mesh_pointer
 
   use specfem_par, only: deltat,ispec_is_anisotropic, &
                          rho_kl,mu_kl,kappa_kl, &
                          c11_kl,c13_kl,c15_kl,c33_kl,c35_kl,c55_kl
+
+  use specfem_par_noise, only: sigma_kl
 
   ! AXISYM case
   use specfem_par, only: AXISYM,is_on_the_axis,hprimeBar_xx,NGLJ
@@ -276,6 +278,10 @@
   else
     ! updates kernels on GPU
     call compute_kernels_elastic_cuda(Mesh_pointer,deltat)
+  endif
+
+  if (NOISE_TOMOGRAPHY == 3) then
+    call compute_kernels_strength_noise(displ_elastic,sigma_kl)
   endif
 
   end subroutine compute_kernels_el

--- a/src/specfem2D/prepare_wavefields.f90
+++ b/src/specfem2D/prepare_wavefields.f90
@@ -35,6 +35,7 @@
 
   use constants, only: IMAIN,USE_ENFORCE_FIELDS
   use specfem_par
+  use specfem_par_noise, only: sigma_kl
 
   implicit none
 
@@ -266,6 +267,13 @@
   bulk_c_kl(:,:,:) = 0.0_CUSTOM_REAL; bulk_beta_kl(:,:,:) = 0.0_CUSTOM_REAL
   c11_kl(:,:,:) = 0.0_CUSTOM_REAL; c13_kl(:,:,:) = 0.0_CUSTOM_REAL; c15_kl(:,:,:) = 0.0_CUSTOM_REAL
   c33_kl(:,:,:) = 0.0_CUSTOM_REAL; c35_kl(:,:,:) = 0.0_CUSTOM_REAL; c55_kl(:,:,:) = 0.0_CUSTOM_REAL
+
+  ! noise source strength kernel
+  if (NOISE_TOMOGRAPHY == 3) then
+    allocate(sigma_kl(NGLLX,NGLLZ,b_nspec_elastic),stat=ier)
+    if (ier /= 0) call stop_the_code('Error allocating noise source kernel array')
+    sigma_kl(:,:,:) = 0.0_CUSTOM_REAL
+  endif
 
   ! for APPROXIMATE_HESS_KL
   allocate(rhorho_el_Hessian_final2(NGLLX,NGLLZ,b_nspec_elastic), &

--- a/src/specfem2D/save_adjoint_kernels.f90
+++ b/src/specfem2D/save_adjoint_kernels.f90
@@ -37,7 +37,10 @@
 
   use constants, only: IMAIN,SAVE_WEIGHTS
 
-  use specfem_par, only: myrank, any_acoustic, any_elastic, any_poroelastic
+  use specfem_par, only: myrank, any_acoustic, any_elastic, any_poroelastic, &
+                         NOISE_TOMOGRAPHY
+
+  use specfem_par_noise, only: sigma_kl
 
   implicit none
 
@@ -61,6 +64,11 @@
   ! save weights for volume integration,
   ! in order to benchmark the kernels with analytical expressions
   if (SAVE_WEIGHTS) call save_weights_kernel()
+
+  ! for noise simulations -- noise strength kernel
+  if (NOISE_TOMOGRAPHY == 3) then
+    call save_kernels_strength_noise(sigma_kl)
+  endif
 
   end subroutine save_adjoint_kernels
 

--- a/src/specfem2D/specfem2D_par.f90
+++ b/src/specfem2D/specfem2D_par.f90
@@ -762,6 +762,9 @@ module specfem_par_noise
   real(kind=CUSTOM_REAL), dimension(:,:), allocatable :: noise_output_array
   real(kind=CUSTOM_REAL), dimension(:), allocatable :: noise_output_rhokl
 
+  ! noise strength kernel
+  real(kind=CUSTOM_REAL), dimension(:,:,:), allocatable :: sigma_kl
+
 end module specfem_par_noise
 
 !=====================================================================


### PR DESCRIPTION
Hi @danielpeter,

I added some subroutines to compute and save the noise strength kernel as done in the SPECFEM3D_CARTESIAN and GLOBAL versions.

Feel free to modify at your convenience,
Best wishes.